### PR TITLE
Fix event schema

### DIFF
--- a/studio/schemas/event.js
+++ b/studio/schemas/event.js
@@ -52,5 +52,17 @@ export default {
         media: <span style={{fontSize: '1.5rem'}}>{visible ? '✅' : '🚧'}</span>
       }
     }
-  }
+  },
+  orderings: [
+    {
+      title: 'Activity',
+      name: 'activity',
+      by: [{field: 'activity.name'}]
+    },
+    {
+      title: 'Date',
+      name: 'date',
+      by: [{field: 'date'}]
+    }
+  ]
 }


### PR DESCRIPTION
* Show time of event in Sanity studio as 24h format.
* Allow event documents to be sorted by activity name and date:
![Screenshot 2022-06-20 at 20 53 36](https://user-images.githubusercontent.com/1183700/174663207-bddf4c20-2f2b-4db3-8ffc-9e67fd0242cc.png)

