### PR TITLE
Fix upcoming events list

### DIFF
--- a/myko/src/lib/sanityClient.ts
+++ b/myko/src/lib/sanityClient.ts
@@ -34,7 +34,7 @@ export function urlFor(client: SanityClientLike, source: SanityImageSource) {
 
 export const notDraft = `!(_id in path('drafts.**'))`;
 
-export const eventGracePeriod = '60*60*2.5' // 2.5 hours
+export const eventGracePeriod = '60*60*2.5'; // 2.5 hours
 // Get all events for an activity that are active:
 //  * not a Sanity draft document,
 //  * 'visible'=true,

--- a/myko/src/lib/sanityClient.ts
+++ b/myko/src/lib/sanityClient.ts
@@ -34,16 +34,17 @@ export function urlFor(client: SanityClientLike, source: SanityImageSource) {
 
 export const notDraft = `!(_id in path('drafts.**'))`;
 
+export const eventGracePeriod = '60*60*2.5' // 2.5 hours
 // Get all events for an activity that are active:
 //  * not a Sanity draft document,
 //  * 'visible'=true,
-//  * and with a date not passed by more than 2.5 hours
+//  * and with a date not passed by more than specified grace period
 export const eventsForActivityFilter = `
   _type == "${sanitySchemaNames.event}" &&
   activity._ref == ^._id &&
   visible == true &&
   ${notDraft} &&
-  dateTime(date) > dateTime(now()) - 60*60*2.5
+  dateTime(date) > dateTime(now()) - ${eventGracePeriod}
 `;
 
 export const attendeesQuery = `

--- a/myko/src/routes/api/jag/index.ts
+++ b/myko/src/routes/api/jag/index.ts
@@ -1,4 +1,4 @@
-import { createReadClient } from '$lib/sanityClient';
+import { createReadClient, eventGracePeriod, notDraft } from '$lib/sanityClient';
 import { sanitySchemaNames } from '$lib/util';
 import type { RequestHandler, ResponseBody } from '@sveltejs/kit';
 
@@ -29,7 +29,10 @@ export const get: RequestHandler<Record<string, string>, ResponseBody> = async (
   const client = await createReadClient();
   const eventsForUserQuery = `*[
     _type == "${sanitySchemaNames.event}" &&
-    references("${userId}")
+    references("${userId}") &&
+    visible == true &&
+    ${notDraft} &&
+    dateTime(date) > dateTime(now()) - ${eventGracePeriod}
   ] | order(date asc) {
     _id,
     date,

--- a/myko/src/routes/jag/index.svelte
+++ b/myko/src/routes/jag/index.svelte
@@ -96,6 +96,7 @@
           <li>
             <a href="/aktiviteter/{event.activity.slug}">
               {formatDate(event.date, { day: 'numeric', month: 'numeric' })}
+              {formatTime(event.date, event.time) }
               {event.activity.name}
             </a>
           </li>

--- a/myko/src/routes/jag/index.svelte
+++ b/myko/src/routes/jag/index.svelte
@@ -96,7 +96,7 @@
           <li>
             <a href="/aktiviteter/{event.activity.slug}">
               {formatDate(event.date, { day: 'numeric', month: 'numeric' })}
-              {formatTime(event.date, event.time) }
+              {formatTime(event.date, event.time)}
               {event.activity.name}
             </a>
           </li>


### PR DESCRIPTION
* Don't show past events in list of upcoming events on '/jag'.
* Show time of event in list of upcoming events.
![Screenshot 2022-09-03 at 22 30 32](https://user-images.githubusercontent.com/1183700/188286804-acab0a61-66db-4650-8cdc-8f8c56903349.png)
