### PR TITLE
Stacks username and login/out button + moves down cotime menu

### DIFF
--- a/myko/src/app.html
+++ b/myko/src/app.html
@@ -81,7 +81,8 @@
     flex-direction: column;
     flex-wrap: wrap;
     min-height: 100vh;
-    padding: 48px 1.5rem 256px;
+    min-width: 100vw;
+    padding: 76px 1.5rem 256px;
     font-family: 'Lato', sans-serif;
     color: var(--grey-800);
   }

--- a/myko/src/lib/components/cotime/CotimeInfo.svelte
+++ b/myko/src/lib/components/cotime/CotimeInfo.svelte
@@ -78,7 +78,7 @@
 
   .header {
     position: absolute;
-    top: 42px;
+    top: 70px;
     font-style: normal;
     font-weight: 500;
     font-size: var(--12px);
@@ -97,7 +97,7 @@
 
   .header-link {
     position: absolute;
-    top: 42px;
+    top: 70px;
     font-style: normal;
     font-weight: 500;
     font-size: var(--12px);

--- a/myko/src/routes/jag/index.svelte
+++ b/myko/src/routes/jag/index.svelte
@@ -132,19 +132,24 @@
   .top-menu button {
     background: var(--grey-050);
     box-shadow: 2px 2px 9px -2px rgb(108 97 97 / 50%);
-    border-radius: 4px;
-    font-family: 'Lato', sans-serif;
-    font-weight: 800;
-    text-align: center;
     color: var(--ocean-800);
-    padding: 8px;
-    border: 0;
+    padding: 4px 6px 6px;
+    margin: 2px 2px 0 0;
+  }
+
+  .top-menu button:hover {
+    background: #fcfcfc;
+    color: var(--ocean-900);
   }
 
   .user-menu {
+    display: flex;
+    flex-direction: column;
+    flex-wrap: wrap;
+    text-align: center;
     position: absolute;
-    top: 10px;
-    right: 10px;
+    top: 8px;
+    right: 6px;
     font-family: 'Roboto Mono', monospace;
     color: var(--grey-800);
   }


### PR DESCRIPTION
Makes the top menu space less crammed, specifically for 'jag' on small screens (though it seems unnecessary to change back the layout on larger screens)