### PR TITLE
Time restriction to visualisation

### DIFF
--- a/myko/src/lib/visualisation/class.js
+++ b/myko/src/lib/visualisation/class.js
@@ -10,6 +10,8 @@ export default class Pictures {
   }
 
   show(nr, weight) {
+    nr = this.xtraCnvs.floor(this.xtraCnvs.random(0, 12));
+
     this.xtraCnvs.imageMode(this.xtraCnvs.CENTER);
     if (this.typeNr > 11) {
       this.xtraCnvs.image(

--- a/myko/src/lib/visualisation/sketch.js
+++ b/myko/src/lib/visualisation/sketch.js
@@ -12,6 +12,7 @@ import { flowfieldDraw, flowfieldSetup } from './flowfield';
 //import { linear } from 'svelte/easing';
 
 let canvas, xtraCnvs, xtraCnvs2;
+let currentDate, currentWeek;
 let addedThings = [],
   addedThingsMove = [];
 let cloud, streetlight, shelf;
@@ -27,7 +28,6 @@ export function preload(p5) {
   cloud = p5.loadImage('cloud0.png');
   streetlight = p5.loadImage('streetlight.png');
   shelf = p5.loadImage('shelves.png');
-  //bucket = p5.loadImage('bucket.png');
 
   for (let i = 1; i < 8; i++) {
     teas.push(p5.loadImage(`tea${i}.png`));
@@ -61,6 +61,10 @@ export async function setup(p5) {
   xtraCnvs2.frameRate(20);
   xtraCnvs2.imageMode[xtraCnvs2.CENTER];
   xtraCnvs2.colorMode(xtraCnvs.HSL, 360, 100, 100, 1.0);
+
+  currentDate = new Date();
+  currentWeek = getWeekDate(currentDate);
+  xtraCnvs.randomSeed(currentWeek);
 
   flowfieldSetup(xtraCnvs2);
   ratio(p5);
@@ -129,8 +133,6 @@ async function fetchActivityLog(p5) {
 }
 
 function checkForNewEntries(logEntries) {
-  const currentDate = new Date();
-  const currentWeek = getWeekDate(currentDate);
   const currentDay = currentDate.getDay();
   const currentHour = currentDate.getHours();
 


### PR DESCRIPTION
- Passes activities on, only when done the same week (counting from jan 1st though so not mon - sun weeks, also, could easily change to every ten days, or whatever you want)
- Finds activities done within the past 120-60 minutes (doesn't do anything different with them for now)
- Activity images are added in a new random order every week. 
    Not sure if this is the best solution, it just takes a picture from a random place in the appropriate image array, using randomSeed(week number) so it will be the same random order during the week. This means you could get the same picture over and over again on a particular week. If you want you can try changing the number in sketch.js line 67.