### PR TITLE
Place the CotimeInfo component on top of visualisation.

### DIFF
--- a/myko/src/lib/visualisation/sketch.js
+++ b/myko/src/lib/visualisation/sketch.js
@@ -94,9 +94,6 @@ function showAdded() {
 
 export function draw(p5) {
   p5.background(2, 106, 116, 100);
-  p5.erase();
-  p5.rect(p5.width * 0.5, 125, 227, 36);
-  p5.noErase();
 
   flowfieldDraw(xtraCnvs2, proportions[2]);
 

--- a/myko/src/routes/index.svelte
+++ b/myko/src/routes/index.svelte
@@ -71,7 +71,9 @@
 
 <main>
   {#if nextUpcomingCotime}
-    <CotimeInfo cotime={nextUpcomingCotime} />
+    <div class="cotime-wrapper">
+      <CotimeInfo cotime={nextUpcomingCotime} />
+    </div>
   {/if}
 
   <!--<h1>Myko</h1>-->
@@ -104,6 +106,10 @@
   p {
     font-size: var(--20px);
     color: var(--grey-050);
+  }
+
+  .cotime-wrapper {
+    z-index: 1;
   }
 
   @media (min-width: 45rem) {


### PR DESCRIPTION
To avoid having a 'cutout' in the visualisation that is then part of the snapshot.

Test by creating a snapshot and verify there's no grey area cutout from the image.