### PR TITLE
Cover canvas cutout with timestamp in snapshot.

### DIFF
--- a/myko/src/routes/index.svelte
+++ b/myko/src/routes/index.svelte
@@ -46,17 +46,19 @@
     const cutOutCenterX = buffer.width * 0.5;
     const cutOutCenterY = 125;
     const cutOutWidth = 229;
+    const cutOutheight = 38;
 
     buffer.fill(229, 245, 238);
     buffer.noStroke();
-    buffer.rect(cutOutCenterX, cutOutCenterY, cutOutWidth, 38);
+    buffer.rect(cutOutCenterX, cutOutCenterY, cutOutWidth, cutOutheight);
 
     const now = new Date();
     const dateText = now.toLocaleString();
     buffer.textFont('Roboto Mono');
     buffer.fill(59, 59, 59);
     buffer.textSize(18);
-    buffer.text(dateText, cutOutCenterX, cutOutCenterY, cutOutWidth);
+    buffer.textAlign(p5Ref.CENTER, p5Ref.CENTER);
+    buffer.text(dateText, cutOutCenterX, cutOutCenterY, cutOutWidth, cutOutheight);
 
     const shortDate = now.toLocaleString('sv-SE', {
       year: '2-digit',

--- a/myko/src/routes/index.svelte
+++ b/myko/src/routes/index.svelte
@@ -42,14 +42,21 @@
       buffer.height
     );
 
-    buffer.textFont('Roboto Mono');
-    buffer.fill(255, 255, 255);
-    buffer.textSize(32);
+    buffer.rectMode(p5Ref.CENTER);
+    const cutOutCenterX = buffer.width * 0.5;
+    const cutOutCenterY = 125;
+    const cutOutWidth = 229;
 
-    const textOffset = 20;
+    buffer.fill(2, 106, 116);
+    buffer.noStroke();
+    buffer.rect(cutOutCenterX, cutOutCenterY, cutOutWidth, 38);
+
     const now = new Date();
     const dateText = now.toLocaleString();
-    buffer.text(dateText, textOffset, buffer.height - textOffset);
+    buffer.textFont('Roboto Mono');
+    buffer.fill(255, 255, 255);
+    buffer.textSize(18);
+    buffer.text(dateText, cutOutCenterX, cutOutCenterY, cutOutWidth);
 
     const shortDate = now.toLocaleString('sv-SE', {
       year: '2-digit',

--- a/myko/src/routes/index.svelte
+++ b/myko/src/routes/index.svelte
@@ -47,14 +47,14 @@
     const cutOutCenterY = 125;
     const cutOutWidth = 229;
 
-    buffer.fill(2, 106, 116);
+    buffer.fill(229, 245, 238);
     buffer.noStroke();
     buffer.rect(cutOutCenterX, cutOutCenterY, cutOutWidth, 38);
 
     const now = new Date();
     const dateText = now.toLocaleString();
     buffer.textFont('Roboto Mono');
-    buffer.fill(255, 255, 255);
+    buffer.fill(59, 59, 59);
     buffer.textSize(18);
     buffer.text(dateText, cutOutCenterX, cutOutCenterY, cutOutWidth);
 


### PR DESCRIPTION
Fill in the area cutout to show the `CotimeInfo` component and cover it with the timestamp in the generated snapshot image.

This is an alternative to #128: it looks slightly uglier in the snapshot, but can be used if the visualisation really should cover that component at the top.