### PR TITLE
Don't make HTML tag <p> 'display: flex'.

### DIFF
--- a/myko/src/app.html
+++ b/myko/src/app.html
@@ -184,12 +184,7 @@
       padding: 40px 0 1rem;
     }
     p {
-      display: flex;
-      justify-content: center;
       width: 35rem;
-    }
-    details > p {
-      justify-content: start;
     }
     /*fix flexbox centering problem for portable text blocks. Nest in a <div class=wrap>*/
     .wrap {

--- a/myko/src/routes/samtid/index.svelte
+++ b/myko/src/routes/samtid/index.svelte
@@ -102,10 +102,6 @@
     font-weight: 700;
   }
 
-  p {
-    display: block;
-  }
-
   @media (min-width: 45rem) {
     li {
       max-width: 23rem;


### PR DESCRIPTION
This is to fix the problem with nested elements shown incorrectly in the FAQ.
How it looks currently:
<img width="590" alt="Fixed" src="https://user-images.githubusercontent.com/1183700/200236982-698799e9-1446-4c08-b8f9-dd04245d601d.png">

With this change:
<img width="590" alt="Fixed" src="https://user-images.githubusercontent.com/1183700/200236865-2aed8469-1a3e-4ca6-9b31-4e5eedff5d7b.png">

I've tried to check that this change doesn't break anything else in the design 🤞 