### PR TITLE
Removes background for newly added visualisation activities

### DIFF
--- a/myko/src/lib/visualisation/pictures.js
+++ b/myko/src/lib/visualisation/pictures.js
@@ -11,6 +11,7 @@ export default class Pictures {
     this.incr = 1.75;
     this.startSize = startSize;
     this.finalSize = size;
+    this.bounceBack = false;
   }
 
   show(weight) {
@@ -48,11 +49,14 @@ export default class Pictures {
   }
 
   grow(nr) {
-    this.startSize += this.incr * (1 / (nr + 1));
-
-    if (this.startSize > this.finalSize * 1.05) {
-      this.incr = 0;
+    if (this.startSize < this.finalSize * 1.12 && !this.bounceBack) {
+      this.startSize += this.incr * (1 / (nr + 1)); //
     }
-    /*try and fix up to size * 1.2 and back down to size * 1, maybe a do while? inside an if block?*/
+    if (this.startSize >= this.finalSize * 1.12 && !this.bounceBack) {
+      this.bounceBack = true;
+    }
+    if (this.startSize >= this.finalSize * 1 && this.bounceBack) {
+      this.startSize -= this.incr;
+    }
   }
 }

--- a/myko/src/lib/visualisation/sketch.js
+++ b/myko/src/lib/visualisation/sketch.js
@@ -186,7 +186,8 @@ function checkForAdds(p5, addedActivities, newness) {
         'diys',
         1.2,
         imagePositions[2],
-        newness
+        newness,
+        p5
       );
     } else {
       wind = true;
@@ -199,14 +200,15 @@ function checkForAdds(p5, addedActivities, newness) {
         'cats',
         1.32,
         imagePositions[0],
-        newness
+        newness,
+        p5
       );
     } else {
       snow = true;
     }
     if ('te-ritual' in addedActivities) {
       rain = false;
-      showThings(addedActivities['te-ritual'], teas, 'teas', 0.82, imagePositions[1], newness);
+      showThings(addedActivities['te-ritual'], teas, 'teas', 0.82, imagePositions[1], newness, p5);
     } else {
       rain = true;
     }
@@ -250,7 +252,7 @@ function checkForAdds(p5, addedActivities, newness) {
   }
 }
 
-function showThings(nr, type, typeName, varySize, locations, newness) {
+function showThings(nr, type, typeName, varySize, locations, newness, p5) {
   for (let i = 0; i < nr; i++) {
     if (i >= locations.length) {
       addedThings.push(
@@ -262,9 +264,7 @@ function showThings(nr, type, typeName, varySize, locations, newness) {
           new Pictures(type, proportions[0] * varySize, typeName, staticLayer, locations, i)
         );
       } else {
-        newAdds.push(
-          new Pictures(type, proportions[0] * varySize, typeName, staticLayer, locations, i, 15)
-        );
+        newAdds.push(new Pictures(type, proportions[0] * varySize, typeName, p5, locations, i, 50));
       }
     }
   }


### PR DESCRIPTION
- Newly added activities for cats/diys/teas displayed by p5 canvas layer instead of 'staticLayer'. p5 layer erases background continously.
- Slight change to the grow animation, first grows larger than images for older activities, then decreases to the same size as the other images