### PR TITLE
Allow anonymous (non-logged in) users

### DIFF
--- a/myko/src/lib/components/StartActivityButton.svelte
+++ b/myko/src/lib/components/StartActivityButton.svelte
@@ -3,6 +3,8 @@
   import type { ActivityStarted } from '$lib/models/startedActivity';
   import { createEventDispatcher, onMount } from 'svelte';
   import LoadingSpinner from './LoadingSpinner.svelte';
+  import { isAuthenticated } from '$lib/auth/store';
+  import { get } from 'svelte/store';
 
   const dispatch = createEventDispatcher<ActivityStarted>();
 
@@ -14,12 +16,12 @@
 
   async function startActivity() {
     loading = true;
-    const accessToken = await authClient.getUserAccessToken();
+    const accessToken = get(isAuthenticated) ? await authClient.getUserAccessToken() : null;
     const response = await fetch('/api/aktiviteter/starta', {
       method: 'POST',
       body: JSON.stringify(data),
       headers: {
-        Authorization: `Bearer ${accessToken}`,
+        ...(accessToken && { Authorization: `Bearer ${accessToken}` }),
         'Content-Type': 'application/json',
       },
     });

--- a/myko/src/lib/components/cotime/CotimeActions.svelte
+++ b/myko/src/lib/components/cotime/CotimeActions.svelte
@@ -14,7 +14,7 @@
 <div class="innerWrapper">
   {#each cotime.events as event}
     <div>
-      {#if $isAuthenticated && event.userIsAttending && event.isStartable}
+      {#if (cotime.activity.allowsAnonymous || ($isAuthenticated && event.userIsAttending)) && event.isStartable}
         <StartActivityButton
           on:activityStarted={onActivityStarted}
           data={{ eventId: event.id }}

--- a/myko/src/lib/models/activity.ts
+++ b/myko/src/lib/models/activity.ts
@@ -53,7 +53,7 @@ export type ActivityEvent = SanityEventType & {
 type Activity = {
   readonly name: string;
   readonly events: ActivityEvent[];
-}
+};
 
 export type SanityActivityType = Activity & {
   readonly slug: string;

--- a/myko/src/lib/models/activity.ts
+++ b/myko/src/lib/models/activity.ts
@@ -29,6 +29,7 @@ export type Cotime = {
   readonly activity: {
     readonly name: string;
     readonly slug: string;
+    readonly allowsAnonymous: boolean;
   };
   readonly date: string;
   readonly events: Event[];
@@ -49,12 +50,13 @@ export type ActivityEvent = SanityEventType & {
   readonly numAttendees: number;
 };
 
-export type SanityActivityType = {
+type Activity = {
   readonly name: string;
   readonly events: ActivityEvent[];
+}
+
+export type SanityActivityType = Activity & {
   readonly slug: string;
-  readonly subactivities?: {
-    readonly name: string;
-    readonly events: ActivityEvent[];
-  }[];
+  readonly allowsAnonymous: boolean;
+  readonly subactivities?: Activity[];
 };

--- a/myko/src/lib/sanityClient.ts
+++ b/myko/src/lib/sanityClient.ts
@@ -67,7 +67,8 @@ export const activityWithNearestEventQuery = `*[
 ] {
     name,
     "events": ${eventsQuery},
-    "slug": slug.current
+    "slug": slug.current,
+    "allowsAnonymous": coalesce(allowsAnonymous, false)
   } [count(events) > 0] | order(events[0].date) [0]
 `;
 

--- a/myko/src/lib/util.ts
+++ b/myko/src/lib/util.ts
@@ -17,12 +17,8 @@ export function userIsAttendee(userId: string, attendees: { _id: string }[] | nu
   return attendees.find((attendee) => attendee._id == userId) !== undefined;
 }
 
-export function eventIsStartable(userId: string | undefined, startDate: string): boolean {
-  if (!userId) {
-    return false;
-  }
-
-  // event is "startable" if user is logged in and it's less than the specified time left before the event start time
+export function eventIsStartable(startDate: string): boolean {
+  // event is "startable" if it's less than the specified time left before the event start time
   const gracePeriodSeconds = 60 * 10;
   const parsedStartDate = Date.parse(startDate);
   const now = new Date().valueOf();
@@ -31,22 +27,23 @@ export function eventIsStartable(userId: string | undefined, startDate: string):
 }
 
 export function computeNextCotime(
-  activity: { events: SanityEventType[]; name: string; slug: string },
+  activity: { events: SanityEventType[]; name: string; slug: string, allowsAnonymous: boolean },
   userId: string | undefined
 ): Cotime {
   // group all events on the same day as the next upcoming event
   const nextDate = activity.events[0].date.split('T')[0];
   const upcomingEvents = activity.events.filter((event) => event.date.startsWith(nextDate));
+  const hasRequiredLoggedInUser = !activity.allowsAnonymous ? !!userId : true
 
   return {
-    activity: { name: activity.name, slug: activity.slug },
+    activity: { name: activity.name, slug: activity.slug, allowsAnonymous: activity.allowsAnonymous },
     date: nextDate,
     events: upcomingEvents.map((event) => {
       return {
         id: event._id,
         time: event.date.split('T')[1],
         ...(userId && { userIsAttending: userIsAttendee(userId, event.attendees) }),
-        isStartable: eventIsStartable(userId, event.date),
+        isStartable: hasRequiredLoggedInUser && eventIsStartable(event.date),
         attendees: event.attendees,
       };
     }),

--- a/myko/src/lib/util.ts
+++ b/myko/src/lib/util.ts
@@ -27,16 +27,20 @@ export function eventIsStartable(startDate: string): boolean {
 }
 
 export function computeNextCotime(
-  activity: { events: SanityEventType[]; name: string; slug: string, allowsAnonymous: boolean },
+  activity: { events: SanityEventType[]; name: string; slug: string; allowsAnonymous: boolean },
   userId: string | undefined
 ): Cotime {
   // group all events on the same day as the next upcoming event
   const nextDate = activity.events[0].date.split('T')[0];
   const upcomingEvents = activity.events.filter((event) => event.date.startsWith(nextDate));
-  const hasRequiredLoggedInUser = !activity.allowsAnonymous ? !!userId : true
+  const hasRequiredLoggedInUser = !activity.allowsAnonymous ? !!userId : true;
 
   return {
-    activity: { name: activity.name, slug: activity.slug, allowsAnonymous: activity.allowsAnonymous },
+    activity: {
+      name: activity.name,
+      slug: activity.slug,
+      allowsAnonymous: activity.allowsAnonymous,
+    },
     date: nextDate,
     events: upcomingEvents.map((event) => {
       return {

--- a/myko/src/routes/aktiviteter/[slug].svelte
+++ b/myko/src/routes/aktiviteter/[slug].svelte
@@ -108,17 +108,13 @@
       </div>
       <div class="instant-btn">
         {#if activity.instant}
-          {#if $isAuthenticated}
-            <StartActivityButton
-              on:activityStarted={activityStarted}
-              data={{ activityId: activity.id }}
-              enabled
-            >
-              Gör nu
-            </StartActivityButton>
-          {:else}
-            <button on:click={login}> Gör nu </button>
-          {/if}
+          <StartActivityButton
+            on:activityStarted={activityStarted}
+            data={{ activityId: activity.id }}
+            enabled
+          >
+            Gör nu
+          </StartActivityButton>
         {/if}
       </div>
     </div>
@@ -153,9 +149,6 @@
 
   .instant-btn {
     max-width: 23%;
-  }
-  button {
-    height: fit-content;
   }
 
   .activity-completed-wrapper {

--- a/myko/src/routes/aktiviteter/[slug].svelte
+++ b/myko/src/routes/aktiviteter/[slug].svelte
@@ -47,10 +47,6 @@
     }
   });
 
-  function login() {
-    authClient.login(currentPage);
-  }
-
   function activityStarted(e: CustomEvent<StartedActivityData>) {
     startedActivityData = e.detail;
     showStartedActivityModal = true;

--- a/myko/src/routes/aktiviteter/[slug].ts
+++ b/myko/src/routes/aktiviteter/[slug].ts
@@ -19,6 +19,7 @@ type SanityResultType = {
   events: SanityEventType[];
   image?: SanityImageSource & { alt: string };
   instant: boolean;
+  allowsAnonymous: boolean;
   name: string;
   prerequisites: string[];
   slug: string;
@@ -44,6 +45,7 @@ function getActivity(slug: string): string {
     "events": ${eventsQuery},
     image,
     instant,
+    "allowsAnonymous": coalesce(allowsAnonymous, false),
     name,
     prerequisites,
     "slug": slug.current

--- a/myko/src/routes/api/aktiviteter/starta.ts
+++ b/myko/src/routes/api/aktiviteter/starta.ts
@@ -6,12 +6,12 @@ import type { SanityClient } from '@sanity/client';
 import type { RequestHandler, ResponseBody } from '@sveltejs/kit';
 
 type ActivityBaseInfo = {
-    _id: string;
-    startedInstructions: PortableTextBlocks;
-    allowsAnonymous: boolean;
-    audioFile: string;
-    videoFile: string;
-}
+  _id: string;
+  startedInstructions: PortableTextBlocks;
+  allowsAnonymous: boolean;
+  audioFile: string;
+  videoFile: string;
+};
 
 type SanityActivityType = ActivityBaseInfo & {
   instant: boolean;
@@ -66,7 +66,7 @@ async function startEvent(writeClient: SanityClient, userId: string | null, even
   if (!event.activity.allowsAnonymous && !userId) {
     // don't allow anonymous user
     return {
-        status: 401,
+      status: 401,
     };
   }
 

--- a/myko/src/routes/jag/index.svelte
+++ b/myko/src/routes/jag/index.svelte
@@ -66,7 +66,6 @@
     return `<li>${date} ${time}: ${activity.activityName}</li>`;
   }
 
-  // export let activity: IActivity;
   export let nextUpcomingCotime: Cotime | undefined = undefined;
 </script>
 

--- a/studio/schemas/activity.js
+++ b/studio/schemas/activity.js
@@ -33,6 +33,12 @@ export default {
       title: 'Instant' // "Gör direkt"
     },
     {
+      name: 'allowsAnonymous',
+      type: 'boolean',
+      initialValue: false,
+      description: 'Whether anonymous (non logged-in) users should be allowed to do the activity'
+    },
+    {
       name: 'prerequisites',
       type: 'array',
       title: 'Prerequisites',

--- a/studio/schemas/activitylog.js
+++ b/studio/schemas/activitylog.js
@@ -27,6 +27,12 @@ export default {
     select: {
         title: 'user.email',
         subtitle: '_createdAt'
+    },
+    prepare({ title, subtitle }) {
+      return {
+        title: title ?? 'Anonymous',
+        subtitle,
+      }
     }
   }
 }


### PR DESCRIPTION
### Description

Allow "instant" (Gör nu) activities and events for certain activities to be performed without being logged-in.

Instant activities are always allowed to be done without being logged-in.
Events for activities are allowed for non-logged in users if the activity has the field `allowsAnonymous` set to `true` via Sanity studio.

### Testing instructions

#### "Instant" activities
0. Ensure you're logged out from the app
1. Go to http://localhost:3000/aktiviteter/halsa-pa-nasims-katter
2. Click on "Gör nu"
3. Verify you're allowed to start the activity without being logged-in

#### Activity that allows anonymous users
Pre-setup: The activity "Gör te-ritual" has been marked with `allowAnonymous: true`.

0. Ensure you're logged out from the app
1. Go to [test event for "Gör te-ritual"](https://myko.sanity.studio/desk/event;756d00c3-52b3-4184-b203-505115a447f0) and set the date to now
2. Go to http://localhost:3000/aktiviteter/te-ritual
3. Ensure the event button shows "Starta <current time>"
4. Click the button
5. Verify you're allowed to start the event without being logged-in